### PR TITLE
Add breakpoints to avoid overlap

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
 
   <div class="container my-5">
     <div class="row">
-      <div class="col-2">
+      <div class="col-sm-2 col-xs-12">
         <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
           <a class="nav-link active" id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home"
             aria-selected="true">Home</a>
@@ -32,7 +32,7 @@
             aria-controls="resources" aria-selected="false">Resource Tiers</a>
         </div>
       </div>
-      <div class="col-10">
+      <div class="col-sm-10 col-xs-12">
         <div class="tab-content" id="v-pills-tabContent">
           <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab"></div>
           <div class="tab-pane fade" id="stateList" role="tabpanel" aria-labelledby="stateList-tab"></div>


### PR DESCRIPTION
Add breakpoints to avoid overlap between the index and the content in the frontpage. This is done automatically by adding bootstrap grid system breakpoints for extra small sizes (since thats where they get overlapped).