### PR TITLE
Change index breakpoint to small

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
 
   <div class="container my-5">
     <div class="row">
-      <div class="col-sm-2 col-xs-12">
+      <div class="col-md-2 col-sm-12">
         <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
           <a class="nav-link active" id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home"
             aria-selected="true">Home</a>


### PR DESCRIPTION
Changed the index breakpoints when the device is small instead of extra small so that it totally prevents an overlap between the sidebar and the main content.